### PR TITLE
Added Riderlink to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ saved/
 *.orig
 *.sln
 *.xlsx
+Plugins/Developer/RiderLink/


### PR DESCRIPTION
Added the rider link plugin to the .gitignore because Rider auto-installs the plugin into new projects