### PR TITLE
Set [HMDPluginPriority] OculusHMD=70 to prevent foricng openXR native…

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,7 +2,7 @@
 ; Since SteamVR also works with the Oculus Rift and Windows Mixed Reality, give priority to the native Oculus and Windows Mixed Reality plugins before trying SteamVR
 OpenXRHMD=60
 WindowsMixedRealityHMD=40
-OculusHMD=20
+OculusHMD=70
 SteamVR=10
 
 [/Script/Engine.GameEngine]


### PR DESCRIPTION
…, in order to enable Meta Quest 3 AR Passthrough capability.

AR Passthrough on Meta Quest 3 wasn't working in VR Expansion Plugin Template project, specifically. This modification fixes that problem.

Fix is one line change to DefaultEngine.ini.
Line 5: OculusHMD=70