### PR TITLE
Add Valid checks to optional subobjects

### DIFF
--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/CharacterMovementCompTypes.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/CharacterMovementCompTypes.cpp
@@ -369,7 +369,7 @@ bool FVRCharacterNetworkMoveData::Serialize(UCharacterMovementComponent& Charact
 
 	if (AVRBaseCharacter* BaseChar = Cast<AVRBaseCharacter>(CharacterOwner))
 	{
-		if (!BaseChar->VRMovementReference->bUseClientControlRotation)
+		if (BaseChar->VRMovementReference && !BaseChar->VRMovementReference->bUseClientControlRotation)
 		{
 			bRepRollAndPitch = (Roll != 0 || Pitch != 0);
 		}

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/GripScripts/GS_GunTools.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/GripScripts/GS_GunTools.cpp
@@ -511,10 +511,13 @@ void UGS_GunTools::GetVirtualStockTarget(UGripMotionControllerComponent * Grippi
 {
 	if (GrippingController && (GrippingController->HasAuthority() || bUseHighQualityRemoteSimulation))
 	{
-		if (AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(GrippingController->GetOwner()); vrOwner && vrOwner->VRReplicatedCamera)
+		if (AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(GrippingController->GetOwner()))
 		{
-			CameraComponent = vrOwner->VRReplicatedCamera;
-			return;
+			if (vrOwner->VRReplicatedCamera)
+			{
+				CameraComponent = vrOwner->VRReplicatedCamera;
+				return;
+			}
 		}
 		else
 		{

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/GripScripts/GS_GunTools.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/GripScripts/GS_GunTools.cpp
@@ -511,7 +511,7 @@ void UGS_GunTools::GetVirtualStockTarget(UGripMotionControllerComponent * Grippi
 {
 	if (GrippingController && (GrippingController->HasAuthority() || bUseHighQualityRemoteSimulation))
 	{
-		if (AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(GrippingController->GetOwner()))
+		if (AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(GrippingController->GetOwner()); vrOwner && vrOwner->VRReplicatedCamera)
 		{
 			CameraComponent = vrOwner->VRReplicatedCamera;
 			return;

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/ParentRelativeAttachmentComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/ParentRelativeAttachmentComponent.cpp
@@ -50,7 +50,7 @@ void UParentRelativeAttachmentComponent::InitializeComponent()
 	Super::InitializeComponent();
 
 	// Update our tracking
-	if (!bUseFeetLocation && IsValid(AttachChar)) // New case to early out and with less calculations
+	if (!bUseFeetLocation && IsValid(AttachChar) && IsValid(AttachChar->VRReplicatedCamera)) // New case to early out and with less calculations
 	{
 		SetRelativeTransform(AttachChar->VRReplicatedCamera->GetRelativeTransform());
 	}

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/ReplicatedVRCameraComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/ReplicatedVRCameraComponent.cpp
@@ -204,7 +204,7 @@ void UReplicatedVRCameraComponent::UpdateTracking(float DeltaTime)
 					Position.Y = 0.0f;
 
 					FRotator StoredCameraRotOffset = FRotator::ZeroRotator;
-					if (AttachChar->VRMovementReference->GetReplicatedMovementMode() == EVRConjoinedMovementModes::C_VRMOVE_Seated)
+					if (AttachChar->VRMovementReference && AttachChar->VRMovementReference->GetReplicatedMovementMode() == EVRConjoinedMovementModes::C_VRMOVE_Seated)
 					{
 						AttachChar->SeatInformation.InitialRelCameraTransform.Rotator();
 					}
@@ -244,7 +244,7 @@ void UReplicatedVRCameraComponent::RunNetworkedSmoothing(float DeltaTime)
 	if (AttachChar && !AttachChar->bRetainRoomscale)
 	{
 		FRotator StoredCameraRotOffset = FRotator::ZeroRotator;
-		if (AttachChar->VRMovementReference->GetReplicatedMovementMode() == EVRConjoinedMovementModes::C_VRMOVE_Seated)
+		if (AttachChar->VRMovementReference && AttachChar->VRMovementReference->GetReplicatedMovementMode() == EVRConjoinedMovementModes::C_VRMOVE_Seated)
 		{
 			AttachChar->SeatInformation.InitialRelCameraTransform.Rotator();
 		}
@@ -470,7 +470,7 @@ void UReplicatedVRCameraComponent::HandleXRCamera()
 							Position.X = 0.0f;
 							Position.Y = 0.0f;
 							//FRotator OffsetRotator = 
-							if (AttachChar->VRMovementReference->GetReplicatedMovementMode() != EVRConjoinedMovementModes::C_VRMOVE_Seated)
+							if (AttachChar->VRMovementReference && AttachChar->VRMovementReference->GetReplicatedMovementMode() != EVRConjoinedMovementModes::C_VRMOVE_Seated)
 							{
 								AttachChar->SeatInformation.InitialRelCameraTransform.Rotator();
 
@@ -521,7 +521,7 @@ void UReplicatedVRCameraComponent::OnRep_ReplicatedCameraTransform()
 		CameraPosition.Y = 0;
 
 		FRotator StoredCameraRotOffset = FRotator::ZeroRotator;
-		if (AttachChar->VRMovementReference->GetReplicatedMovementMode() == EVRConjoinedMovementModes::C_VRMOVE_Seated)
+		if (AttachChar->VRMovementReference && AttachChar->VRMovementReference->GetReplicatedMovementMode() == EVRConjoinedMovementModes::C_VRMOVE_Seated)
 		{
 			AttachChar->SeatInformation.InitialRelCameraTransform.Rotator();
 		}

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacterMovementComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacterMovementComponent.cpp
@@ -2017,8 +2017,11 @@ void UVRBaseCharacterMovementComponent::SmoothCorrection(const FVector& OldLocat
 			// I am currently skipping smoothing on rotation operations
 			if ((!OldRotation.Equals(NewRotation, 1e-5f)))// || Velocity.IsNearlyZero()))
 			{
-				BaseVRCharacterOwner->NetSmoother->SetRelativeLocation(BaseVRCharacterOwner->bRetainRoomscale ? FVector::ZeroVector : BaseVRCharacterOwner->VRRootReference->GetTargetHeightOffset());			
-				//BaseVRCharacterOwner->NetSmoother->SetRelativeLocation(FVector::ZeroVector);
+				if (BaseVRCharacterOwner->NetSmoother)
+				{
+					BaseVRCharacterOwner->NetSmoother->SetRelativeLocation(BaseVRCharacterOwner->bRetainRoomscale ? FVector::ZeroVector : BaseVRCharacterOwner->VRRootReference->GetTargetHeightOffset());			
+					//BaseVRCharacterOwner->NetSmoother->SetRelativeLocation(FVector::ZeroVector);
+				}
 				UpdatedComponent->SetWorldLocationAndRotation(NewLocation, NewRotation, false, nullptr, GetTeleportType());
 				ClientData->MeshTranslationOffset = FVector::ZeroVector;
 				ClientData->MeshRotationOffset = ClientData->MeshRotationTarget;
@@ -2152,7 +2155,7 @@ void UVRBaseCharacterMovementComponent::SmoothClientPosition_UpdateVRVisuals()
 
 	if (ClientData)
 	{
-		if (NetworkSmoothingMode == ENetworkSmoothingMode::Linear)
+		if (NetworkSmoothingMode == ENetworkSmoothingMode::Linear && BaseVRCharacterOwner->NetSmoother)
 		{
 			// Erased most of the code here, check back in later
 			const USceneComponent* MeshParent = BaseVRCharacterOwner->NetSmoother->GetAttachParent();
@@ -2167,7 +2170,7 @@ void UVRBaseCharacterMovementComponent::SmoothClientPosition_UpdateVRVisuals()
 			FVector HeightOffset = (BaseVRCharacterOwner->bRetainRoomscale ? FVector::ZeroVector : BaseVRCharacterOwner->VRRootReference->GetTargetHeightOffset());
 			BaseVRCharacterOwner->NetSmoother->SetRelativeLocation(NewRelLocation + HeightOffset);
 		}
-		else if (NetworkSmoothingMode == ENetworkSmoothingMode::Exponential)
+		else if (NetworkSmoothingMode == ENetworkSmoothingMode::Exponential && BaseVRCharacterOwner->NetSmoother)
 		{
 			const USceneComponent* MeshParent = BaseVRCharacterOwner->NetSmoother->GetAttachParent();
 			FVector MeshParentScale = MeshParent != nullptr ? MeshParent->GetComponentScale() : FVector(1.0f, 1.0f, 1.0f);

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRRootComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRRootComponent.cpp
@@ -422,12 +422,15 @@ void UVRRootComponent::BeginPlay()
 {
 	Super::BeginPlay();
 
-	if(AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(this->GetOwner()); vrOwner && vrOwner->VRReplicatedCamera)
-	{ 
-		TargetPrimitiveComponent = vrOwner->VRReplicatedCamera;
-		owningVRChar = vrOwner;
-		//VRCameraCollider = vrOwner->VRCameraCollider;
-		return;
+	if(AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(this->GetOwner()))
+	{
+		if (vrOwner->VRReplicatedCamera)
+		{
+			TargetPrimitiveComponent = vrOwner->VRReplicatedCamera;
+			owningVRChar = vrOwner;
+			//VRCameraCollider = vrOwner->VRCameraCollider;
+			return;
+		}
 	}
 	else
 	{
@@ -754,17 +757,23 @@ void UVRRootComponent::SetSimulatePhysics(bool bSimulate)
 
 	if (bSimulate)
 	{
-		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()); OwningCharacter && OwningCharacter->NetSmoother)
+		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()))
 		{
-			OwningCharacter->NetSmoother->SetRelativeLocation(FVector(0.f,0.f, -this->GetUnscaledCapsuleHalfHeight()));
+			if (OwningCharacter->NetSmoother)
+			{
+				OwningCharacter->NetSmoother->SetRelativeLocation(FVector(0.f,0.f, -this->GetUnscaledCapsuleHalfHeight()));
+			}
 		}	
 		this->AddWorldOffset(this->GetComponentRotation().RotateVector(FVector(0.f, 0.f, this->GetScaledCapsuleHalfHeight())), false, nullptr, ETeleportType::TeleportPhysics);
 	}
 	else
 	{
-		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()); OwningCharacter && OwningCharacter->NetSmoother)
+		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()))
 		{
-			OwningCharacter->NetSmoother->SetRelativeLocation(FVector(0.f, 0.f, 0));
+			if (OwningCharacter->NetSmoother)
+			{
+				OwningCharacter->NetSmoother->SetRelativeLocation(FVector(0.f, 0.f, 0));
+			}
 		}
 		this->AddWorldOffset(this->GetComponentRotation().RotateVector(FVector(0.f, 0.f, -this->GetScaledCapsuleHalfHeight())), false, nullptr, ETeleportType::TeleportPhysics);
 	}

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRRootComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRRootComponent.cpp
@@ -422,7 +422,7 @@ void UVRRootComponent::BeginPlay()
 {
 	Super::BeginPlay();
 
-	if(AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(this->GetOwner()))
+	if(AVRBaseCharacter * vrOwner = Cast<AVRBaseCharacter>(this->GetOwner()); vrOwner && vrOwner->VRReplicatedCamera)
 	{ 
 		TargetPrimitiveComponent = vrOwner->VRReplicatedCamera;
 		owningVRChar = vrOwner;
@@ -456,7 +456,7 @@ void UVRRootComponent::SetTrackingPaused(bool bPaused)
 
 void UVRRootComponent::UpdateCharacterCapsuleOffset()
 {
-	if (owningVRChar && !owningVRChar->bRetainRoomscale)
+	if (owningVRChar && !owningVRChar->bRetainRoomscale && owningVRChar->NetSmoother)
 	{
 		if (!FMath::IsNearlyEqual(LastCapsuleHalfHeight, CapsuleHalfHeight))
 		{
@@ -754,7 +754,7 @@ void UVRRootComponent::SetSimulatePhysics(bool bSimulate)
 
 	if (bSimulate)
 	{
-		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()))
+		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()); OwningCharacter && OwningCharacter->NetSmoother)
 		{
 			OwningCharacter->NetSmoother->SetRelativeLocation(FVector(0.f,0.f, -this->GetUnscaledCapsuleHalfHeight()));
 		}	
@@ -762,7 +762,7 @@ void UVRRootComponent::SetSimulatePhysics(bool bSimulate)
 	}
 	else
 	{
-		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()))
+		if (AVRCharacter* OwningCharacter = Cast<AVRCharacter>(GetOwner()); OwningCharacter && OwningCharacter->NetSmoother)
 		{
 			OwningCharacter->NetSmoother->SetRelativeLocation(FVector(0.f, 0.f, 0));
 		}

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRStereoWidgetComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRStereoWidgetComponent.cpp
@@ -574,7 +574,7 @@ void UVRStereoWidgetComponent::TickComponent(float DeltaTime, enum ELevelTick Ti
 					// Set transform to this relative transform
 
 					bool bHandledTransform = false;
-					if (AVRBaseCharacter* BaseVRChar = Cast<AVRBaseCharacter>(mpawn))
+					if (AVRBaseCharacter* BaseVRChar = Cast<AVRBaseCharacter>(mpawn); BaseVRChar && BaseVRChar->VRReplicatedCamera)
 					{
 						if (USceneComponent* CameraParent = BaseVRChar->VRReplicatedCamera->GetAttachParent())
 						{

--- a/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRStereoWidgetComponent.cpp
+++ b/Plugins/VRExpansionPlugin/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRStereoWidgetComponent.cpp
@@ -574,30 +574,33 @@ void UVRStereoWidgetComponent::TickComponent(float DeltaTime, enum ELevelTick Ti
 					// Set transform to this relative transform
 
 					bool bHandledTransform = false;
-					if (AVRBaseCharacter* BaseVRChar = Cast<AVRBaseCharacter>(mpawn); BaseVRChar && BaseVRChar->VRReplicatedCamera)
+					if (AVRBaseCharacter* BaseVRChar = Cast<AVRBaseCharacter>(mpawn))
 					{
-						if (USceneComponent* CameraParent = BaseVRChar->VRReplicatedCamera->GetAttachParent())
+						if (BaseVRChar->VRReplicatedCamera)
 						{
-							FTransform DeltaTrans = FTransform::Identity;
-							if (!BaseVRChar->bRetainRoomscale)
+							if (USceneComponent* CameraParent = BaseVRChar->VRReplicatedCamera->GetAttachParent())
 							{
-								FVector HMDLoc;
-								FQuat HMDRot;
-								GEngine->XRSystem->GetCurrentPose(IXRTrackingSystem::HMDDeviceId, HMDRot, HMDLoc);
-
-								HMDLoc.Z = 0.0f;
-
-								if (AVRCharacter* VRChar = Cast<AVRCharacter>(mpawn))
+								FTransform DeltaTrans = FTransform::Identity;
+								if (!BaseVRChar->bRetainRoomscale)
 								{
-									HMDLoc += UVRExpansionFunctionLibrary::GetHMDPureYaw_I(HMDRot.Rotator()).RotateVector(FVector(VRChar->VRRootReference->VRCapsuleOffset.X, VRChar->VRRootReference->VRCapsuleOffset.Y, 0.0f));
+									FVector HMDLoc;
+									FQuat HMDRot;
+									GEngine->XRSystem->GetCurrentPose(IXRTrackingSystem::HMDDeviceId, HMDRot, HMDLoc);
+
+									HMDLoc.Z = 0.0f;
+
+									if (AVRCharacter* VRChar = Cast<AVRCharacter>(mpawn))
+									{
+										HMDLoc += UVRExpansionFunctionLibrary::GetHMDPureYaw_I(HMDRot.Rotator()).RotateVector(FVector(VRChar->VRRootReference->VRCapsuleOffset.X, VRChar->VRRootReference->VRCapsuleOffset.Y, 0.0f));
+									}
+
+									DeltaTrans = FTransform(FQuat::Identity, HMDLoc, FVector(1.0f));
 								}
 
-								DeltaTrans = FTransform(FQuat::Identity, HMDLoc, FVector(1.0f));
+								Transform = OffsetTransform.GetRelativeTransform(CameraParent->GetComponentTransform());
+								Transform = (FTransform(FRotator(0.f, -180.f, 0.f)) * Transform) * DeltaTrans;
+								bHandledTransform = true;
 							}
-
-							Transform = OffsetTransform.GetRelativeTransform(CameraParent->GetComponentTransform());
-							Transform = (FTransform(FRotator(0.f, -180.f, 0.f)) * Transform) * DeltaTrans;
-							bHandledTransform = true;
 						}
 					}
 					else if (UCameraComponent* Camera = mpawn->FindComponentByClass<UCameraComponent>())


### PR DESCRIPTION
Not everything will work as originally intended when subobjects are removed.
Obviously.
But this will help with crashes.